### PR TITLE
chore(merge): feature/dependabot -> develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,6 @@ version: 2
 updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
+    target-branch: "develop"
     schedule:
       interval: "daily"


### PR DESCRIPTION
The default branch was changed from develop to main. Changed Dependabot to target develop.